### PR TITLE
Move away from SSH remotes in stack.yaml

### DIFF
--- a/stack.yaml
+++ b/stack.yaml
@@ -5,18 +5,18 @@ packages:
 
 extra-deps:
 - language-lua-0.11.0.1
-- git: git@github.com:jkoppel/language-javascript.git
+- git: https://github.com/jkoppel/language-javascript.git
   commit: 3b2026cf9c443bc798683c12206de439354283ce
 - language-dot-0.1.1
-- git: git@github.com:jkoppel/language-c.git
+- git: https://github.com/jkoppel/language-c.git
   commit: 49c340419e9ea6395c1915f9de7aedf903483c95
-- git: git@github.com:jkoppel/language-java.git
+- git: https://github.com/jkoppel/language-java.git
   commit: a41ba850a1e2b3e233cc8e5132433921b6a6dca0
 - language-python-0.5.8
 - concurrent-supply-0.1.8@sha256:9373f4868ad28936a7b93781b214ef4afdeacf377ef4ac729583073491c9f9fb,1627
 - wl-pprint-1.2.1@sha256:aea676cff4a062d7d912149d270e33f5bb0c01b68a9db46ff13b438141ff4b7c,734
 - alex-tools-0.4@sha256:7f24cb60ba88b04196965e78d7944d638b1a6034f0c9284bdf7d95e05c7be7c3,995
-- git: git@github.com:jkoppel/cubix.git
+- git: https://github.com/jkoppel/cubix.git
   commit: 7ff7866103ab2b5a2109465d4a39b2247640f0ae
   subdirs:
   - .


### PR DESCRIPTION
This required openssh (missing on the default Stack Docker image)